### PR TITLE
MariaDB Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,35 @@ C module for MySQL
 **To build on macOS:**
 
 ```sh
-swift build -Xlinker -L/usr/local/lib
+swift build -Xswiftc -I/usr/local/include/mysql -Xlinker -L/usr/local/lib
 ```
+
+- `-I` tells the compiler where to find the MySQL header file `mysql.h`.
+- `-L` tells the linker where to find MySQL library `libmysqlclient`.
 
 **To build on Linux:**
 
-```sh
-swift build -Xswiftc -I/usr/include/mariadb -Xlinker -L/usr/lib/x86_64-linux-gnu
-```
+`swift build` should work normally.
 
-- `-I` tells the compiler where to find the MariaDB header file `mysql.h`
-- `-L` tells the linker where to find MariaDB library.
-  - On macOS the library is called `libmysqlclient`, and on Linux the library is `libmariadb`.
-  
 ## MariaDB
 
-To use MariaDB instead of MySQL, add the following compiler flag when building:
+To use MariaDB instead of MySQL, you just need to change a couple of the compiler flags.
+
+**macOS:**
 
 ```sh
--Xswiftc -DMARIADB
+swift build -Xlinker -L/usr/local/lib -Xswiftc -DMARIADB -Xswiftc -DNOJSON
 ```
 
-- This tells the compiler to link the MariaDB library instead of the MySQL library.
+- `-DMARIADB` tells the compiler to link the MariaDB library instead of the MySQL library.
+- `-DNOJSON` tells the package to ignore the `JSON` type (not supported as of MariaDB 10.1.16).
+
+**Linux:**
+
+```sh
+swift build -Xswiftc -I/usr/include/mariadb -Xlinker -L/usr/lib/x86_64-linux-gnu -Xswiftc -DMARIADB -Xswiftc -DNOJSON
+```
+
+- This simply changes the library/header paths and sets the same compatibility options shown above.
+- Note that on macOS the library is called `libmysqlclient`, while on Linux the library is called `libmariadb`.
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
-# Qutheory - CMySQL - (Not Tested)
+# CMySQL
+C module for MySQL
 
-## Install MySQL via Brew (OS X) 
-follow link to download page http://dev.mysql.com/downloads/mysql/
+## Building
 
-You may need to use the following command to build if you experience errors.
+**To build on macOS:**
 
 ```sh
-swift build -Xswiftc -I -Xswiftc /usr/local/mysql/include/ -Xlinker -L -Xlinker /usr/local/mysql/lib/
+swift build -Xlinker -L/usr/local/lib
 ```
 
-## Install MySQL via APT-GET (Linux)
+**To build on Linux:**
 
-* Update your system (you may need ```sudo```):
-```
-apt-get update
-apt-get upgrade
+```sh
+swift build -Xswiftc -I/usr/include/mariadb -Xlinker -L/usr/lib/x86_64-linux-gnu
 ```
 
-* To install MySQL ...
+- `-I` tells the compiler where to find the MariaDB header file `mysql.h`
+- `-L` tells the linker where to find MariaDB library.
+  - On macOS the library is called `libmysqlclient`, and on Linux the library is `libmariadb`.
+  
+## MariaDB
 
-```
-apt-get install mysql-server
+To use MariaDB instead of MySQL, add the following compiler flag when building:
+
+```sh
+-Xswiftc -DMYSQL
 ```
 
+- This tells the compiler to link the MariaDB library instead of the MySQL library.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ swift build -Xswiftc -I/usr/include/mariadb -Xlinker -L/usr/lib/x86_64-linux-gnu
 To use MariaDB instead of MySQL, add the following compiler flag when building:
 
 ```sh
--Xswiftc -DMYSQL
+-Xswiftc -DMARIADB
 ```
 
 - This tells the compiler to link the MariaDB library instead of the MySQL library.

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,16 +1,14 @@
-#if MARIADB
-module CMySQLLinux [system] {
-    header "/usr/include/mariadb/mysql.h"
-    link "mariadb"
-    export *
-}
-#else
 module CMySQLLinux [system] {
     header "/usr/include/mysql/mysql.h"
     link "mysqlclient"
     export *
 }
-#endif
+
+module CMariaDBLinux [system] {
+    header "/usr/include/mariadb/mysql.h"
+    link "mariadb"
+    export *
+}
 
 module CMySQLMac [system] {
     header "/usr/local/include/mysql/mysql.h"

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,8 +1,16 @@
+#if MARIADB
+module CMySQLLinux [system] {
+    header "/usr/include/mariadb/mysql.h"
+    link "mariadb"
+    export *
+}
+#else
 module CMySQLLinux [system] {
     header "/usr/include/mysql/mysql.h"
     link "mysqlclient"
     export *
 }
+#endif
 
 module CMySQLMac [system] {
     header "/usr/local/include/mysql/mysql.h"


### PR DESCRIPTION
This PR adds compatibility for MariaDB. It exports an additional module for linking the MariaDB client library, which may be imported by the Swift database driver if desired.
