### PR TITLE
Fix CMySQL on Heroku

### DIFF
--- a/macos.pc
+++ b/macos.pc
@@ -1,7 +1,7 @@
 prefix=/usr/local/opt/mysql
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
-includedir=${prefix}/include/mysql
+includedir=${prefix}/include
 Name: MySQL
 Description: MySQL client library
 Version: 2.0

--- a/shim.h
+++ b/shim.h
@@ -1,6 +1,6 @@
 #ifndef __CMYSQL_SHIM_H__
 #define __CMYSQL_SHIM_H__
 
-#include <mysql.h>
+#include <mysql/mysql.h>
 
 #endif


### PR DESCRIPTION
There's no working option to install a custom pkg-config for libmysqlclient on Heroku, we've seen that before. But that was a mistaken path in the first place.

Changing the shim to import `mysql/mysql.h` fixes builds on Heroku! (This is possible as `/usr/include` is already on the include path.) This _suggests_ that the cmysql APT package is unnecessary in the first place.

The macos.pc file needed to be updated to accommodate this change, but after changing it locally, Xcode builds work again too.

This hopefully resolves #8.