### PR TITLE
Remove custom pkgconfig references to fix compatibility with MySQL 8.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "CMySQL",
-    pkgConfig: "cmysql",
+    pkgConfig: "mysqlclient",
     providers: [
-        .Brew("cmysql"),
-        .Apt("cmysql")
+        .Brew("mysql"),
+        .Apt("libmysqlclient-dev")
     ]
 )

--- a/macos.pc
+++ b/macos.pc
@@ -1,9 +1,0 @@
-prefix=/usr/local/opt/mysql
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
-Name: MySQL
-Description: MySQL client library
-Version: 2.0
-Cflags: -I${includedir}
-Libs: -L${libdir} -lmysqlclient


### PR DESCRIPTION
As it says on the tin. The custom cmysql pkg-config was a mistake, and now is the perfect time to drop it.